### PR TITLE
Add hard drive serial number to collected information

### DIFF
--- a/Tool/SuperCAT.ps1
+++ b/Tool/SuperCAT.ps1
@@ -128,7 +128,7 @@ if(($Choices -Contains 0) -and ($Choices -NotContains 7)){
 if((($Choices -Contains 1) -or ($Choices -Contains 6)) -and ($Choices -NotContains 7)){
     $SerialNumber = (Get-WMIObject -Class Win32_BIOS).SerialNumber
     $MACAddress   = (Get-WMIObject -Class Win32_NetworkAdapter | Where-Object {$Null -ne $_.MACaddress} | Select-Object -First 1).MACAddress
-    $HardDrives   = Get-PhysicalDisk | Select-Object FriendlyName,Model,MediaType,BusType,HealthStatus,OperationalStatus,Usage,Size
+    $HardDrives   = Get-PhysicalDisk | Select-Object FriendlyName,Model,SerialNumber,MediaType,BusType,HealthStatus,OperationalStatus,Usage,Size
     $OSName       = $Win32OS.Caption
     $OSVer        = $Win32OS.Version
 


### PR DESCRIPTION
Fix for https://github.com/SuperCATDevelopers/SuperCAT/issues/43. 

This can also lead to a naming convention of output files to better distinguish individual systems and run times. 
e.g `ComputerName-HardDriveSerialNumber-Time-X.txt`