### PR TITLE
Pull Windows Defender Logs

### DIFF
--- a/Tool/Modules/Antivirus.psm1
+++ b/Tool/Modules/Antivirus.psm1
@@ -33,21 +33,26 @@ function Import-AntivirusLog {
     # Sends any available antivirus logs to the location of the script.
 
     param (
-        [Parameter(Mandatory=$True,ValueFromPipeline=$True,Position=0)]
+        [Parameter(Mandatory=$True,Position=0)]
         [ValidateNotNullOrEmpty()]
-        [String]$LogPrefix
+        [String]$McAfeePrefix,
+
+        [Parameter(Mandatory=$True,Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [String]$EventLogsPrefix
     )
 
-    if (!$(Test-Path $($LogPrefix | Split-Path))) { New-Item -ItemType Directory -Path $($LogPrefix | Split-Path) | Out-Null }
+    if (!$(Test-Path $($McAfeePrefix | Split-Path))) { New-Item -ItemType Directory -Path $($McAfeePrefix | Split-Path) | Out-Null }
+    if (!$(Test-Path $($EventLogsPrefix | Split-Path))) { New-Item -ItemType Directory -Path $($EventLogsPrefix | Split-Path) | Out-Null }
     Write-Host "Gathering scan logs..."
     if (Test-Path -PathType Leaf -Path "C:\ProgramData\McAfee\DestkopProtection\OnDemandScanLog.txt"){
-        Copy-Item -Path "C:\ProgramData\McAfee\DestkopProtection\OnDemandScanLog.txt" -Destination "$LogPrefix`_OnDemandScanLog.txt"
+        Copy-Item -Path "C:\ProgramData\McAfee\DestkopProtection\OnDemandScanLog.txt" -Destination "$McAfeePrefix`_OnDemandScanLog.txt"
     }
     if (Test-Path -PathType Leaf -Path "C:\ProgramData\McAfee\Endpoint Security\Logs\*"){
-        Copy-Item -Path "C:\ProgramData\McAfee\Endpoint Security\Logs\" -Destination "$LogPrefix`_EndpointSecurity\" -Recurse
+        Copy-Item -Path "C:\ProgramData\McAfee\Endpoint Security\Logs\" -Destination "$McAfeePrefix`_EndpointSecurity\" -Recurse
     }
     if ($(wevtutil.exe el).Contains("Microsoft-Windows-Windows Defender/Operational")){
-        wevtutil.exe epl "Microsoft-Windows-Windows Defender/Operational" "$LogPrefix`_WindowsDefender.evtx"
+        wevtutil.exe epl "Microsoft-Windows-Windows Defender/Operational" "$EventLogsPrefix`_WindowsDefender.evtx"
     }
 }
 Export-ModuleMember -Function Import-AntivirusLog

--- a/Tool/SuperCAT.ps1
+++ b/Tool/SuperCAT.ps1
@@ -245,14 +245,14 @@ if(([Security.Principal.WindowsPrincipal](
 
     Write-Warning "THIS SCRIPT WAS NOT RUN AS AN ADMINISTRATOR! SOME TASKS MAY NOT WORK OR PROVIDE INACCURATE RESULTS!"
 }
-
+$LogPath = "$ScriptDirectory..\..\Outputs"
 ## Fix time on the laptop, and set it to UTC
 Set-Time | Out-Null
+
 $Config = Import-Config "$ScriptDirectory\config.xml" |
     Update-Config -RootDirectory $ScriptDirectory |
     Export-Config "$ScriptDirectory\config.xml" -PassThru
 $LogPrefix = Get-LogPrefix $Config $ScriptDirectory
-$LogPath = "$ScriptDirectory..\..\Outputs"
 $AllOptions = @(
     "Update Antivirus (Requires Pre-Approved Actions)",
     "Collect Computer Information",

--- a/Tool/SuperCAT.ps1
+++ b/Tool/SuperCAT.ps1
@@ -283,7 +283,7 @@ while ($Chosen -notcontains $AllOptions[-1]) {
         $AllOptions[0]  { Update-AVSignature $ScriptDirectory }
         $AllOptions[1]  { Import-Identifier $Config "$ScriptDirectory\..\..\Outputs\GatheredLogs\$LogPrefix" }
         $AllOptions[2]  { $ExitLock += Start-Antivirus $ScriptDirectory "$ScriptDirectory\..\..\Outputs\AVLogs\$LogPrefix" }
-        $AllOptions[3]  { Import-AntivirusLog "$ScriptDirectory\..\..\Outputs\AVLogs" }
+        $AllOptions[3]  { Import-AntivirusLog "$ScriptDirectory\..\..\Outputs\AVLogs\$LogPrefix" }
         $AllOptions[4]  { $ExitLock += Start-SCAP $ScriptDirectory "$ScriptDirectory\..\..\Outputs\SCAPLogs\$(Get-LogPrefix $Config $ScriptDirectory -SCAP)" }
         $AllOptions[5]  { Import-EventLog "$ScriptDirectory\..\..\Outputs\EventLogs\$LogPrefix"}
         $AllOptions[-2] { throw "`$AllOptions[-2] if statement failed to evaluate correctly." }

--- a/Tool/SuperCAT.ps1
+++ b/Tool/SuperCAT.ps1
@@ -282,7 +282,7 @@ while ($Chosen -notcontains $AllOptions[-1]) {
     switch($Chosen) {
         $AllOptions[0]  { Update-AVSignature $ScriptDirectory }
         $AllOptions[1]  { Import-Identifier $Config "$LogPath\GatheredLogs\$LogPrefix" }
-        $AllOptions[2]  { $ExitLock += Start-Antivirus $ScriptDirectory "$LogPath\AVLogs\$LogPrefix" }
+        $AllOptions[2]  { $ExitLock += Start-Antivirus $ScriptDirectory "$LogPath\McAfeeLogs\$LogPrefix" }
         $AllOptions[3]  { Import-AntivirusLog "$LogPath\McAfeeLogs\$LogPrefix" "$LogPath\EventLogs\$LogPrefix" }
         $AllOptions[4]  { $ExitLock += Start-SCAP $ScriptDirectory "$LogPath\SCAPLogs\$(Get-LogPrefix $Config $ScriptDirectory -SCAP)" }
         $AllOptions[5]  { Import-EventLog "$LogPath\EventLogs\$LogPrefix"}

--- a/Tool/SuperCAT.ps1
+++ b/Tool/SuperCAT.ps1
@@ -248,11 +248,11 @@ if(([Security.Principal.WindowsPrincipal](
 
 ## Fix time on the laptop, and set it to UTC
 Set-Time | Out-Null
-
 $Config = Import-Config "$ScriptDirectory\config.xml" |
     Update-Config -RootDirectory $ScriptDirectory |
     Export-Config "$ScriptDirectory\config.xml" -PassThru
 $LogPrefix = Get-LogPrefix $Config $ScriptDirectory
+$LogPath = "$ScriptDirectory..\..\Outputs"
 $AllOptions = @(
     "Update Antivirus (Requires Pre-Approved Actions)",
     "Collect Computer Information",
@@ -281,11 +281,11 @@ while ($Chosen -notcontains $AllOptions[-1]) {
     }
     switch($Chosen) {
         $AllOptions[0]  { Update-AVSignature $ScriptDirectory }
-        $AllOptions[1]  { Import-Identifier $Config "$ScriptDirectory\..\..\Outputs\GatheredLogs\$LogPrefix" }
-        $AllOptions[2]  { $ExitLock += Start-Antivirus $ScriptDirectory "$ScriptDirectory\..\..\Outputs\AVLogs\$LogPrefix" }
-        $AllOptions[3]  { Import-AntivirusLog "$ScriptDirectory\..\..\Outputs\AVLogs\$LogPrefix" }
-        $AllOptions[4]  { $ExitLock += Start-SCAP $ScriptDirectory "$ScriptDirectory\..\..\Outputs\SCAPLogs\$(Get-LogPrefix $Config $ScriptDirectory -SCAP)" }
-        $AllOptions[5]  { Import-EventLog "$ScriptDirectory\..\..\Outputs\EventLogs\$LogPrefix"}
+        $AllOptions[1]  { Import-Identifier $Config "$LogPath\GatheredLogs\$LogPrefix" }
+        $AllOptions[2]  { $ExitLock += Start-Antivirus $ScriptDirectory "$LogPath\AVLogs\$LogPrefix" }
+        $AllOptions[3]  { Import-AntivirusLog "$LogPath\McAfeeLogs\$LogPrefix" "$LogPath\EventLogs\$LogPrefix" }
+        $AllOptions[4]  { $ExitLock += Start-SCAP $ScriptDirectory "$LogPath\SCAPLogs\$(Get-LogPrefix $Config $ScriptDirectory -SCAP)" }
+        $AllOptions[5]  { Import-EventLog "$LogPath\EventLogs\$LogPrefix"}
         $AllOptions[-2] { throw "`$AllOptions[-2] if statement failed to evaluate correctly." }
         $AllOptions[-1] { Out-Null }
         {$_.Contains("(Complete) ")} {


### PR DESCRIPTION
SuperCAT currently pulls McAfee logs from computers, but fails if they aren't found. Instead, check and pull both McAfee locations and Windows Defender event logs.